### PR TITLE
Update UnitsConverter plugin to be .NET 8 and FS 1.0 compliant

### DIFF
--- a/plugins-manifest.json
+++ b/plugins-manifest.json
@@ -75,10 +75,10 @@
     "DisplayName": "Units Converter",
     "Description": "Converts quantity in different units",
     "PublisherName": "Zhichao Hong",
-    "Version": "1.1.0.0",
+    "Version": "1.1.0.1",
     "MinimumFluentSearchVersion": null,
     "URL": "https://github.com/ZhichaoHong/UnitsConverter.Fluent.Plugin",
-    "DownloadURL": "https://stfluentsearch.blob.core.windows.net/fluent-search-plugins/UnitsConverter.Fluent.Plugin.1.1.0.0.zip",
+    "DownloadURL": "https://github.com/ZhichaoHong/UnitsConverter.Fluent.Plugin/releases/download/v1.1.0.1/UnitsConverter1.1.0.1.zip",
     "IconUrl": null,
     "IconGlyph": "",
     "IconBase64": null

--- a/plugins-manifest.json
+++ b/plugins-manifest.json
@@ -75,10 +75,10 @@
     "DisplayName": "Units Converter",
     "Description": "Converts quantity in different units",
     "PublisherName": "Zhichao Hong",
-    "Version": "1.0.6.1",
+    "Version": "1.1.0.0",
     "MinimumFluentSearchVersion": null,
     "URL": "https://github.com/ZhichaoHong/UnitsConverter.Fluent.Plugin",
-    "DownloadURL": "https://stfluentsearch.blob.core.windows.net/fluent-search-plugins/UnitsConverter.Fluent.Plugin.1.0.6.1.zip",
+    "DownloadURL": "https://stfluentsearch.blob.core.windows.net/fluent-search-plugins/UnitsConverter.Fluent.Plugin.1.1.0.0.zip",
     "IconUrl": null,
     "IconGlyph": "",
     "IconBase64": null


### PR DESCRIPTION
@adirh3 , I have updated the manifest. In the plugin repo, I made a release tag 1.1.0.0 that the plugin changes includes.